### PR TITLE
fix: update problem difficulty mappings for new difficulty system

### DIFF
--- a/src/lib/difficulty.ts
+++ b/src/lib/difficulty.ts
@@ -1,2 +1,2 @@
-export const problemDifficultyName = ['暂无评定', '入门', '普及-', '普及/提高-', '普及+/提高', '提高+/省选-', '省选/NOI-', 'NOI/NOI+/CTSC'];
-export const problemDifficultyMapToOld = (d: number) => [0, 2, 3, 5, 6, 8, 10, 11][d];
+export const problemDifficultyName = ['暂无评定', '入门', '普及-', '普及', '普及+/提高-', '提高', '提高+/省选-', '省选/NOI-', 'NOI/NOI+/CTSC'];
+export const problemDifficultyMapToOld = (d: number) => [0, 2, 3, 5, 6, 8, 9, 10, 11][d];


### PR DESCRIPTION
由于洛谷对难度体系进行了调整，原有的修改题目难度的功能受到了影响。

参见 [难度体系更新计划](https://www.luogu.com.cn/discuss/1310714)。